### PR TITLE
feat: 'login/purchase' 결제 및 로그인 페이지 스타일링 디테일 수정

### DIFF
--- a/CSS/reset.css
+++ b/CSS/reset.css
@@ -2,7 +2,6 @@
     body {
         margin: 0;
         padding: 0;
-        width: 100vw;
     }
 
     h1, h2, h3, h4, h5, h6 {

--- a/sub/login/login.css
+++ b/sub/login/login.css
@@ -10,7 +10,7 @@ body {
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    width: 25%;
+    width: 23%;
     margin: 0 auto;
 }
 
@@ -20,7 +20,7 @@ header {
 header .logo-box-login {
     display: flex;
     justify-content: flex-start;
-    margin: 20px auto 20px;
+    margin: 20px auto 10px;
 }
 header .nike-logo-login {
     width: 48px;
@@ -40,7 +40,7 @@ header .jordan-logo-login .jordan-logo-icon-login {
 }
 
 main .information-login {
-    font-size: 29px;
+    font-size: 27px;
     line-height: 35px;
     margin: 20px auto 20px;
 }
@@ -65,7 +65,7 @@ main .login-login .email-login {
     height: 60px;
     font-size: 16px;
     color: #707073;
-    padding: 10px;
+    padding: 7px;
 }
 main .agree-login {
     font-size: 16px;

--- a/sub/login/login.css
+++ b/sub/login/login.css
@@ -1,7 +1,11 @@
 @import url(../../CSS/reset.css);
 @import url(../../CSS/common.css);
 
-.container {
+body {
+    font-family: 'Noto Sans KR', sans-serif;
+}
+
+.container-login {
     display: flex;
     flex-direction: column;
     justify-content: center;

--- a/sub/login/login.html
+++ b/sub/login/login.html
@@ -12,7 +12,7 @@
 
 </head>
 <body>
-    <div class="container">
+    <div class="container-login">
 
         <header>
             <div class="logo-box-login">

--- a/sub/login/login.html
+++ b/sub/login/login.html
@@ -33,7 +33,7 @@
                 <a class="change-login" href="#">변경</a>
             </div>
             <div class="login-login">
-                <input class="email-login" type="email" value="이메일*">
+                <input class="email-login" type="email" placeholder="이메일*">
             </div>
             <h2 class="agree-login">계속 진행하면 나이키의 <span class="personal-information-login">개인정보 처리방침</span> 및 <span
                     class="terms-of-use-login">이용약관</span>

--- a/sub/purchase/purchase.css
+++ b/sub/purchase/purchase.css
@@ -1,0 +1,191 @@
+@import url(../../CSS/reset.css);
+@import url(../../CSS/common.css);
+
+body {
+    font-family: 'Noto Sans KR', sans-serif;
+}
+
+.container-purchase {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    margin: auto 30px;
+
+}
+header {
+    width: 100%;
+}
+header .logo-box-purchase {
+    display: flex;
+    justify-content: space-between;
+}
+header .logo-box-purchase .nike-logo-purchase {
+    width: 77px;
+    height: 77px;
+}
+header .logo-box-purchase .nike-logo-purchase .nike-logo-icon-purchase {
+    width: 57px;
+    height: 57px;
+}
+header .logo-box-purchase .cart-purchase {
+    width: 24px;
+    height: 24px;
+    margin-top: 10px;
+}
+header .logo-box-purchase .cart-purchase .cart-logo-icon-purchase {
+    width: 24px;
+    height: 24px;
+}
+header .logo-box-purchase .cart-purchase .cart-number-purchase {
+    font-size: 10px;
+    position: absolute;
+    top: 19px;
+    right: 24px;
+}
+main {
+    width: 60%;
+}
+main .pay-purchase {
+    text-align: center;
+    font-size: 25px;
+    margin: 40px 0;
+    font-weight: 550;
+}
+main .pay-container-purchase {
+    display: flex;
+    position: relative;
+}
+main .pay-container-purchase .shipping-options-purchase {
+    width: 60%;
+    margin: 10px 0;
+}
+main .pay-container-purchase .shipping-options-purchase .so-purchase {
+    font-size: 25px;
+    font-weight: 550;
+    margin-bottom: 30px;
+}
+main .pay-container-purchase .shipping-options-purchase ul li {
+    width: 49%;
+    margin: 0 0.5%;
+}
+main .pay-container-purchase .shipping-options-purchase .how-to-buy-purchase {
+    display: flex;
+    /*background: red;*/
+
+}
+main .pay-container-purchase .shipping-options-purchase .how-to-buy-purchase .shipping-purchase, .pickup-purchase {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 60px;
+    border: 1px solid #cccccc;
+    border-radius: 10px;
+    font-size:16px;
+}
+main .pay-container-purchase .shipping-options-purchase .how-to-buy-purchase .shipping-purchase .truck-icon-purchase {
+    margin-right: 10px;
+}
+main .pay-container-purchase .shipping-options-purchase .how-to-buy-purchase .pickup-purchase .location-icon-purchase {
+    margin-right: 4px;
+}
+main .pay-container-purchase .shipping-options-purchase .name-purchase {
+    display: flex;
+}
+main .pay-container-purchase .shipping-options-purchase .name-purchase .last-name-purchase, .first-name-purchase {
+    width: 100%;
+    height: 60px;
+    border: 1px solid #cccccc;
+    border-radius: 10px;
+    color: #707073;
+    font-size: 16px;
+    font-weight: 550;
+    margin: 30px 0;
+    padding-left: 10px;
+}
+main .pay-container-purchase .shipping-options-purchase .address-purchase {
+    display: flex;
+    flex-wrap: wrap;
+}
+main .pay-container-purchase .shipping-options-purchase .road-name-address-purchase {
+    width: 100%;
+    height: 60px;
+    border: 1px solid #cccccc;
+    border-radius: 10px;
+    color: #707073;
+    font-size: 16px;
+    font-weight: 550;
+    padding-left: 10px;
+}
+main .pay-container-purchase .shipping-options-purchase .input-address-purchase {
+    font-size: 12px;
+    color: #707073;
+    text-decoration: underline;
+    text-decoration-color: #121212;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 4px;
+    margin: 30px 0;
+}
+main .pay-container-purchase .shipping-options-purchase .contact-purchase {
+    display: flex;
+}
+main .pay-container-purchase .shipping-options-purchase .contact-purchase .phone-number-purchase, .email-purchase {
+    width: 100%;
+    height: 60px;
+    border: 1px solid #cccccc;
+    border-radius: 10px;
+    color: #707073;
+    font-size: 16px;
+    font-weight: 550;
+    padding-left: 10px;
+}
+main .pay-container-purchase .shipping-options-purchase .guide-purchase {
+    display: flex;
+    justify-content: space-between;
+}
+main .pay-container-purchase .shipping-options-purchase .guide-purchase .sms-purchase {
+    font-size: 12px;
+    color: #707073;
+    margin-top: 10px;
+    margin-left: 15px;
+}
+main .pay-container-purchase .shipping-options-purchase .guide-purchase .save-continue-purchase {
+    width: 130px;
+    height: 55px;
+    border: solid #e6e6e6;
+    border-radius: 30px;
+    color: #9f9fa1;
+    background: #e6e6e6;
+    font-size: 16px;
+    font-weight: 550;
+    margin-top: 40px;
+    margin-bottom: 20px;
+}
+main .pay-container-purchase .shipping-options-purchase .payment-purchase {
+    color: #707073;
+    font-size: 25px;
+    font-weight: 550;
+    padding: 30px 0;
+    border-top: 1px solid #e6e6e6;
+    border-bottom: 1px solid #e6e6e6;
+}
+main .pay-container-purchase .shipping-options-purchase .order-completed-purchase {
+    color: #707073;
+    font-size: 25px;
+    font-weight: 550;
+    padding: 30px 0;
+    border-bottom: 1px solid #e6e6e6;
+}
+
+
+main .pay-container-purchase .shopping-cart-purchase {
+    width: 40%;
+    margin: 10px 0;
+}
+
+.footer .nav .link-global{
+    position: relative;
+    padding-right: 1650px;
+    margin-right: auto;
+    font-weight: 500;
+}

--- a/sub/purchase/purchase.css
+++ b/sub/purchase/purchase.css
@@ -41,7 +41,7 @@ header .logo-box-purchase .cart-purchase .cart-number-purchase {
     font-size: 10px;
     position: absolute;
     top: 19px;
-    right: 24px;
+    right: 39px;
 }
 main {
     width: 60%;
@@ -66,15 +66,24 @@ main .pay-container-purchase .shipping-options-purchase .so-purchase {
     margin-bottom: 30px;
 }
 main .pay-container-purchase .shipping-options-purchase ul li {
-    width: 49%;
-    margin: 0 0.5%;
+    width: 48%;
+    margin: 0 1%;
 }
 main .pay-container-purchase .shipping-options-purchase .how-to-buy-purchase {
     display: flex;
     /*background: red;*/
 
 }
-main .pay-container-purchase .shipping-options-purchase .how-to-buy-purchase .shipping-purchase, .pickup-purchase {
+main .pay-container-purchase .shipping-options-purchase .how-to-buy-purchase .shipping-purchase {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 60px;
+    border: 2px solid #000000;
+    border-radius: 10px;
+    font-size:16px;
+}
+main .pay-container-purchase .shipping-options-purchase .how-to-buy-purchase .pickup-purchase {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -181,6 +190,76 @@ main .pay-container-purchase .shipping-options-purchase .order-completed-purchas
 main .pay-container-purchase .shopping-cart-purchase {
     width: 40%;
     margin: 10px 0;
+    padding: 0 60px;
+}
+main .pay-container-purchase .shopping-cart-purchase .shopping-cart-edit-purchase {
+    display: flex;
+    justify-content: space-between;
+}
+main .pay-container-purchase .shopping-cart-purchase .shopping-cart-edit-purchase .cart-purchase {
+    font-size: 25px;
+    font-weight: 550;
+}
+main .pay-container-purchase .shopping-cart-purchase .shopping-cart-edit-purchase .edit-purchase {
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 5px;
+    font-weight: 550;
+    margin-top: 8px;
+}
+main .pay-container-purchase .shopping-cart-purchase .price-container-purchase {
+    display: flex;
+    justify-content: space-between;
+    padding: 40px 0 25px;
+    border-bottom: 1px solid #e6e6e6;
+}
+main .pay-container-purchase .shopping-cart-purchase .price-container-purchase .amount-purchase {
+
+}
+main .pay-container-purchase .shopping-cart-purchase .price-container-purchase .amount-purchase .delivery-fee-purchase {
+    padding: 20px 0;
+}
+main .pay-container-purchase .shopping-cart-purchase .price-container-purchase .amount-purchase .total-payment-amount-purchase {
+    font-weight: 550;
+}
+main .pay-container-purchase .shopping-cart-purchase .price-container-purchase .price-purchase {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: flex-end;
+}
+main .pay-container-purchase .shopping-cart-purchase .price-container-purchase .price-purchase .delivery-fee-price-purchase {
+    padding: 20px 0;
+}
+main .pay-container-purchase .shopping-cart-purchase .price-container-purchase .price-purchase .total-payment-amount-price-purchase {
+    font-weight: 550;
+}
+main .pay-container-purchase .shopping-cart-purchase .arrive-purchase {
+    font-weight: 550;
+    padding: 30px 0 30px;
+}
+main .pay-container-purchase .shopping-cart-purchase .product-information-purchase {
+    display: flex;
+}
+main .pay-container-purchase .shopping-cart-purchase .product-information-purchase .product-photos-purchase {
+    width: 60px;
+    height: 60px;
+}
+main .pay-container-purchase .shopping-cart-purchase .product-information-purchase .product-container-purchase {
+    margin-left: 25px;
+}
+main .pay-container-purchase .shopping-cart-purchase .product-information-purchase .product-container-purchase .product-name-purchase {
+    font-size: 15px;
+    font-weight: 360;
+    padding-bottom: 10px;
+    letter-spacing: 0.5px;
+}
+main .pay-container-purchase .shopping-cart-purchase .product-information-purchase .product-container-purchase .product-post-purchase {
+    font-size: 15px;
+    font-weight: 400;
+    color: #707073;
+    letter-spacing: 0.5px;
+    line-height: 25px;
 }
 
 .footer .nav .link-global{

--- a/sub/purchase/purchase.html
+++ b/sub/purchase/purchase.html
@@ -45,23 +45,23 @@
                     </ul>
                     <ul class="name-purchase">
                         <li>
-                            <input class="last-name-purchase" type="text" value="성*">
+                            <input class="last-name-purchase" type="text" placeholder="성*">
                         </li>
                         <li>
-                            <input class="first-name-purchase" type="text" value="이름*">
+                            <input class="first-name-purchase" type="text" placeholder="이름*">
                         </li>
                     </ul>
                     <div class="address-purchase">
                         <input class="road-name-address-purchase" type="text"
-                               value="🔍︎ 주소 찾기: 도로명, 건물명 또는 지번으로 검색 예) 테헤란로 152, 혹은 역삼동 737">
+                               placeholder="🔍︎ 주소 찾기: 도로명, 건물명 또는 지번으로 검색 예) 테헤란로 152, 혹은 역삼동 737">
                         <a class="input-address-purchase" href="#">직접 주소 입력</a>
                     </div>
                     <ul class="contact-purchase">
                         <li>
-                            <input class="phone-number-purchase" type="tel" value="전화번호*">
+                            <input class="phone-number-purchase" type="tel" placeholder="전화번호*">
                         </li>
                         <li>
-                            <input class="email-purchase" type="email" value="이메일*">
+                            <input class="email-purchase" type="email" placeholder="이메일*">
                         </li>
                     </ul>
                     <div class="guide-purchase">
@@ -73,34 +73,39 @@
                 </section>
 
                 <section class="shopping-cart-purchase">
-                    <h2 class="cart-purchase">장바구니</h2>
-                    <a class="edit-purchase" href="#">수정</a>
-                    <div>
+                    <div class="shopping-cart-edit-purchase">
+                        <h2 class="cart-purchase">장바구니</h2>
+                        <a class="edit-purchase" href="#">수정</a>
+                    </div>
+                    <div class="price-container-purchase">
                         <div class="amount-purchase">
-                            <p class="product-amount-purchase">상품 금액 <img src="../../img/sub/help-icon.png"
-                                                                          alt="정보 아이콘">
+                            <p class="product-amount-purchase">상품 금액
+                                <img class="help-icon-purchase" src="../../img/sub/help-icon.png" alt="정보 아이콘">
                             </p>
                             <p class="delivery-fee-purchase">배송비</p>
                             <p class="total-payment-amount-purchase">총 결제 금액</p>
                         </div>
                         <div class="price-purchase">
-                            <p class="product-amount-price-purchase">139,000 원</p>
+                            <p class="product-amount-price-purchase">129,000 원</p>
                             <p class="delivery-fee-price-purchase">0 원</p>
-                            <p class="total-payment-amount-price-purchase">139,000 원</p>
+                            <p class="total-payment-amount-price-purchase">129,000 원</p>
                         </div>
                     </div>
-                    <p class="arrive-purchase">5월 29일 (목)까지 도착 예정</p>
+                    <p class="arrive-purchase">5월 31일 (토)까지 도착 예정</p>
                     <div class="product-information-purchase">
                         <img class="product-photos-purchase"
-                             src="https://static.nike.com/a/images/w_96,h_96,f_auto,q_auto,e_sharpen:100/95b641f2-9dd1-4720-a195-5f15c5c357d9/A%27ONE+EP.png"
+                             src="https://static.nike.com/a/images/w_96,h_96,f_auto,q_auto,e_sharpen:100/1c39aad7-f503-4622-a558-9f22f198b478/LEBRON+WITNESS+VIII+EP.png"
                              alt="상품 사진">
-                        <p class="product-post-purchase">에이원 'OG 펄스' EP 에이자 윌슨 농구화 <br>
-                            스타일 번호: FZ8606-100 <br>
-                            사이즈: 260 <br>
-                            컬러: 화이트/오프 화이트/서밋 화이트 <br>
-                            수량: 1 / 139,000 원 <br>
-                            139,000 원
-                        </p>
+                        <div class="product-container-purchase">
+                            <p class="product-name-purchase">르브론 위트니스 VIII EP 농구화</p>
+                            <p class="product-post-purchase">
+                                스타일 번호: HQ2140-700 <br>
+                                사이즈: 260 <br>
+                                컬러: 유니버시티 골드/라이트 크... <br>
+                                수량: 1 / 129,000 원 <br>
+                                129,000 원
+                            </p>
+                        </div>
                     </div>
                 </section>
             </div>

--- a/sub/purchase/purchase.html
+++ b/sub/purchase/purchase.html
@@ -5,102 +5,152 @@
     <meta name="viewport"
           content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>Title</title>
-    <link rel="stylesheet" href="purchase.css">
+    <title>Checkout. Nike.com</title>
     <link rel="stylesheet" href="../../CSS/common.css">
+    <link rel="stylesheet" href="purchase.css">
+    <link rel="icon" href="../../img/sub/nike-logo-icon-2.png" type="image/png">
+
 </head>
 <body>
+    <div class="container-purchase">
 
-    <header>
-
-        <div class="nike-logo-purchase">
-            <img class="nike-logo-icon-purchase" src="../../img/sub/nike-logo-icon.png" alt="나이키 로고 아이콘">
-        </div>
-        <div class="cart-purchase">
-            <img class="cart-logo-icon-purchase" src="../../img/sub/cart-icon.png" alt="카트 아이콘">
-        </div>
-
-    </header>
-
-    <main>
-
-        <h1 class="pay-purchase">결제하기</h1>
-        <section class="shipping-options-purchase">
-
-            <h2 class="so-purchase">배송 옵션</h2>
-            <ul>
-                <li class="shipping-purchase">
-                    <img class="truck-icon-purchase" src="../../img/sub/truck-icon.png" alt="트럭 아이콘"> 배송
-                </li>
-                <li class="pickup-purchase">
-                    <img class="location-icon-purchase" src="../../img/sub/location-icon.png" alt="위치 아이콘"> 매장 픽업
-                </li>
-            </ul>
-            <ul>
-                <li>
-                    <input class="last-name-purchase" type="text" value="성*">
-                </li>
-                <li>
-                    <input class="first-name-purchase" type="text" value="이름*">
-                </li>
-            </ul>
-            <div>
-                <input class="road-name-address-purchase" type="text" value="주소 찾기: 도로명, 건물명 또는 지번으로 검색 예) 테헤란로 152, 혹은 역삼동 737">
-                <a class="input-address-purchase" href="#">직접 주소 입력</a>
-            </div>
-            <ul>
-                <li>
-                    <input class="phone-number-purchase" type="tel" value="전화번호*">
-                </li>
-                <li>
-                    <input class="email-purchase" type="email" value="이메일*">
-                </li>
-            </ul>
-            <div>
-                <p class="sms-purchase">모든 주문 관련 안내는 SMS로 전송됩니다.</p>
-                <button class="save-continue-purchase">저장 및 계속</button>
-            </div>
-            <p class="payment-purchase">결제</p>
-            <p class="order-completed-purchase">주문 완료</p>
-
-        </section>
-        <section class="shopping-cart-purchase">
-
-            <h2 class="cart-purchase">In Your Cart</h2>
-            <a class="edit-purchase" href="#">Edit</a>
-            <div>
-                <div class="amount-purchase">
-                    <p class="product-amount-purchase">상품 금액 <img src="../../img/sub/help-icon.png" alt="정보 아이콘"></p>
-                    <p class="delivery-fee-purchase">배송비</p>
-                    <p class="total-payment-amount-purchase">총 결제 금액</p>
+        <header>
+            <div class="logo-box-purchase">
+                <div class="nike-logo-purchase">
+                    <img class="nike-logo-icon-purchase" src="../../img/sub/nike-logo-icon-2.png" alt="나이키 로고 아이콘">
                 </div>
-                <div class="price-purchase">
-                    <p class="product-amount-price-purchase">139,000 원</p>
-                    <p class="delivery-fee-price-purchase">0 원</p>
-                    <p class="total-payment-amount-price-purchase">139,000 원</p>
+                <div class="cart-purchase">
+                    <img class="cart-logo-icon-purchase" src="../../img/sub/cart-icon.png" alt="카트 아이콘">
+                    <p class="cart-number-purchase">1</p>
                 </div>
             </div>
-            <p class="arrive-purchase">5월 29일 (목)까지 도착 예정</p>
-            <div class="product-information-purchase">
-                <img class="product-photos-purchase" src="https://static.nike.com/a/images/w_96,h_96,f_auto,q_auto,e_sharpen:100/95b641f2-9dd1-4720-a195-5f15c5c357d9/A%27ONE+EP.png" alt="상품 사진">
-                <p class="product-post-purchase">에이원 'OG 펄스' EP 에이자 윌슨 농구화 <br>
-                    스타일 번호: FZ8606-100 <br>
-                    사이즈: 260 <br>
-                    컬러: 화이트/오프 화이트/서밋 화이트 <br>
-                    수량: 1 / 139,000 원 <br>
-                    139,000 원</p>
+        </header>
+
+        <main>
+
+            <h1 class="pay-purchase">결제하기</h1>
+
+            <div class="pay-container-purchase">
+
+                <section class="shipping-options-purchase">
+                    <h2 class="so-purchase">배송 옵션</h2>
+                    <ul class="how-to-buy-purchase">
+                        <li class="shipping-purchase">
+                            <img class="truck-icon-purchase" src="../../img/sub/truck-icon.png" alt="트럭 아이콘"> 배송
+                        </li>
+                        <li class="pickup-purchase">
+                            <img class="location-icon-purchase" src="../../img/sub/location-icon.png" alt="위치 아이콘"> 매장
+                            픽업
+                        </li>
+                    </ul>
+                    <ul class="name-purchase">
+                        <li>
+                            <input class="last-name-purchase" type="text" value="성*">
+                        </li>
+                        <li>
+                            <input class="first-name-purchase" type="text" value="이름*">
+                        </li>
+                    </ul>
+                    <div class="address-purchase">
+                        <input class="road-name-address-purchase" type="text"
+                               value="🔍︎ 주소 찾기: 도로명, 건물명 또는 지번으로 검색 예) 테헤란로 152, 혹은 역삼동 737">
+                        <a class="input-address-purchase" href="#">직접 주소 입력</a>
+                    </div>
+                    <ul class="contact-purchase">
+                        <li>
+                            <input class="phone-number-purchase" type="tel" value="전화번호*">
+                        </li>
+                        <li>
+                            <input class="email-purchase" type="email" value="이메일*">
+                        </li>
+                    </ul>
+                    <div class="guide-purchase">
+                        <p class="sms-purchase">모든 주문 관련 안내는 SMS로 전송됩니다.</p>
+                        <button class="save-continue-purchase">저장 및 계속</button>
+                    </div>
+                    <p class="payment-purchase">결제</p>
+                    <p class="order-completed-purchase">주문 완료</p>
+                </section>
+
+                <section class="shopping-cart-purchase">
+                    <h2 class="cart-purchase">장바구니</h2>
+                    <a class="edit-purchase" href="#">수정</a>
+                    <div>
+                        <div class="amount-purchase">
+                            <p class="product-amount-purchase">상품 금액 <img src="../../img/sub/help-icon.png"
+                                                                          alt="정보 아이콘">
+                            </p>
+                            <p class="delivery-fee-purchase">배송비</p>
+                            <p class="total-payment-amount-purchase">총 결제 금액</p>
+                        </div>
+                        <div class="price-purchase">
+                            <p class="product-amount-price-purchase">139,000 원</p>
+                            <p class="delivery-fee-price-purchase">0 원</p>
+                            <p class="total-payment-amount-price-purchase">139,000 원</p>
+                        </div>
+                    </div>
+                    <p class="arrive-purchase">5월 29일 (목)까지 도착 예정</p>
+                    <div class="product-information-purchase">
+                        <img class="product-photos-purchase"
+                             src="https://static.nike.com/a/images/w_96,h_96,f_auto,q_auto,e_sharpen:100/95b641f2-9dd1-4720-a195-5f15c5c357d9/A%27ONE+EP.png"
+                             alt="상품 사진">
+                        <p class="product-post-purchase">에이원 'OG 펄스' EP 에이자 윌슨 농구화 <br>
+                            스타일 번호: FZ8606-100 <br>
+                            사이즈: 260 <br>
+                            컬러: 화이트/오프 화이트/서밋 화이트 <br>
+                            수량: 1 / 139,000 원 <br>
+                            139,000 원
+                        </p>
+                    </div>
+                </section>
             </div>
 
-        </section>
+        </main>
 
-    </main>
+        <footer class="footer">
+            <nav class="nav">
+                <a href="#" class="link link-global">대한민국</a>
+            </nav>
+            <ul class="menu">
+                <li>&copy; 2025 Nike, Inc. All Rights Reserved</li>
+                <li><a href="#">이용약관</a></li>
+                <li><a href="#"><strong>개인정보처리방침</strong></a></li>
+                <li><a href="#">위치정보이용약관</a></li>
+                <li><a href="#">영상정보처리기기 운영 방침</a></li>
+            </ul>
+            <div class="txt">
+                <div>
+                    <p>
+                        <span>유)나이키코리아 대표 Kimberlee Lynn Chang Mendes, 킴벌리 린 창 멘데스</span>
+                        <span>서울 강남구 테헤란로 152 강남파이낸스센터 30층</span>
+                        <span>통신판매업신고번호 2011-서울강남-03461</span>
+                        <span>
+                        등록번호 220-88-09068
+                        <a href="#">사업자 정보 확인</a>
+                    </span>
+                    </p>
+                    <p>
+                    <span>
+                        고객센터 전화 문의
+                        <a href="tel:#">080-022-0182</a>
+                        FAX 02-6744-5880
+                    </span>
+                        <span>
+                        이메일
+                        <a href="mailto:#">service@nike.co.kr</a>
+                    </span>
+                        <span>호스팅서비스사업자 (유)나이키코리아</span>
+                    </p>
+                </div>
+                <p>
+                    현금 등으로 결제 시 안전 거래를 위해 나이키 쇼핑몰에서 가입하신 한국결제네트웍스 유한회사의 구매안전 서비스(결제대금예치)를 이용하실 수 있습니다.
+                    콘텐츠산업진흥법에 의한 콘텐츠 보호 안내
+                    <a href="#">자세히 보기</a>
+                </p>
+            </div>
+        </footer>
 
-    <footer>
-
-
-
-    </footer>
-
+    </div>
 
 </body>
 </html>


### PR DESCRIPTION
#23

## 작업 내용 요약
- 결제 및 로그인 페이지 전체 스타일링 마무리
- 폰트, 간격, 정렬 등 세부 UI 디테일 수정
- reset.css 내 불필요한 `width: 100vw` 속성 제거

## 브랜치
- login/purchase

## 관련 커밋
- style: 결제 페이지 스타일링 완료 및 디테일 수정
- style: 로그인 페이지 스타일링 디테일 수정
- docs: reset.css에서 width: 100vw 삭제

## 수락 기준
- 결제 및 로그인 페이지가 시안과 동일하게 반응형 및 스타일 구현 완료
- 스크롤바 이슈 없이 모든 뷰포트에서 정상 렌더링 확인
- 공통 reset.css 파일 정리 완료