### PR TITLE
docs: 메인 페이지 중복 테그(body) 삭제

### DIFF
--- a/main/main.kdh.html
+++ b/main/main.kdh.html
@@ -258,11 +258,11 @@
                 <img src="../img/main/membership-1.avif" alt="멤버 리워드">
 
 
-            <div class="ms-text-kdh">
-                <p>멤버 리워드</p>
-                <p>운동과 쇼핑을 위한 특별한 혜택</p>
-                <a href="#">자세히 보기</a>
-            </div>
+                <div class="ms-text-kdh">
+                    <p>멤버 리워드</p>
+                    <p>운동과 쇼핑을 위한 특별한 혜택</p>
+                    <a href="#">자세히 보기</a>
+                </div>
 
             </div>
 
@@ -271,9 +271,9 @@
                 <img src="../img/main/membership-2.avif" alt="스포츠">
 
                 <div class="ms-text-kdh">
-                <p>스포츠 & 웰니스 앱</p>
-                <p>언제 어디서든 운동하기</p>
-                <a href="#">함께 운동하기</a>
+                    <p>스포츠 & 웰니스 앱</p>
+                    <p>언제 어디서든 운동하기</p>
+                    <a href="#">함께 운동하기</a>
                 </div>
 
             </div>
@@ -282,14 +282,12 @@
                 <img src="../img/main/membership-3.avif" alt="SNKRS">
 
                 <div class="ms-text-kdh">
-                <p>SNKRS</p>
-                <p>최고의 스니커즈 커뮤니티</p>
-                <a href="#">자세히 보기</a>
+                    <p>SNKRS</p>
+                    <p>최고의 스니커즈 커뮤니티</p>
+                    <a href="#">자세히 보기</a>
                 </div>
 
             </div>
-
-
 
 
         </div>
@@ -327,79 +325,78 @@
 
         </div>
 
-        <body>
-            <footer class="footer">
-                <nav class="nav">
-                    <ul>
-                        <li class="title">안내</li>
-                        <li><a href="#">멤버가입</a></li>
-                        <li><a href="#">매장찾기</a></li>
-                        <li><a href="#">제품 가이드</a></li>
-                        <li><a href="#">러닝화 가이드</a></li>
-                    </ul>
-                    <ul>
-                        <li class="title">맴버 혜택</li>
-                        <li><a href="#">웰컴 쿠폰</a></li>
-                        <li><a href="#">생일 쿠폰</a></li>
-                        <li><a href="#">학생 할인 쿠폰</a></li>
-                    </ul>
-                    <ul>
-                        <li class="title">고객센터</li>
-                        <li><a href="#">주문배송조회</a></li>
-                        <li><a href="#">반품 정책</a></li>
-                        <li><a href="#">결제 방법</a></li>
-                        <li><a href="#">공지사항</a></li>
-                        <li><a href="#">문의하기</a></li>
-                    </ul>
-                    <ul>
-                        <li class="title">회사소개</li>
-                        <li><a href="#">About Nike</a></li>
-                        <li><a href="#">소식</a></li>
-                        <li><a href="#">채용</a></li>
-                        <li><a href="#">투자자</a></li>
-                        <li><a href="#">지속가능성</a></li>
-                        <li><a href="#">신고하기</a></li>
-                    </ul>
-                    <a href="#" class="link link-global">대한민국</a>
-                </nav>
-                <ul class="menu">
-                    <li>&copy; 2025 Nike, Inc. All Rights Reserved</li>
-                    <li><a href="#">이용약관</a></li>
-                    <li><a href="#"><strong>개인정보처리방침</strong></a></li>
-                    <li><a href="#">위치정보이용약관</a></li>
-                    <li><a href="#">영상정보처리기기 운영 방침</a></li>
+        <footer class="footer">
+            <nav class="nav">
+                <ul>
+                    <li class="title">안내</li>
+                    <li><a href="#">멤버가입</a></li>
+                    <li><a href="#">매장찾기</a></li>
+                    <li><a href="#">제품 가이드</a></li>
+                    <li><a href="#">러닝화 가이드</a></li>
                 </ul>
-                <div class="txt">
-                    <div>
-                        <p>
-                            <span>유)나이키코리아 대표 Kimberlee Lynn Chang Mendes, 킴벌리 린 창 멘데스</span>
-                            <span>서울 강남구 테헤란로 152 강남파이낸스센터 30층</span>
-                            <span>통신판매업신고번호 2011-서울강남-03461</span>
-                            <span>
+                <ul>
+                    <li class="title">맴버 혜택</li>
+                    <li><a href="#">웰컴 쿠폰</a></li>
+                    <li><a href="#">생일 쿠폰</a></li>
+                    <li><a href="#">학생 할인 쿠폰</a></li>
+                </ul>
+                <ul>
+                    <li class="title">고객센터</li>
+                    <li><a href="#">주문배송조회</a></li>
+                    <li><a href="#">반품 정책</a></li>
+                    <li><a href="#">결제 방법</a></li>
+                    <li><a href="#">공지사항</a></li>
+                    <li><a href="#">문의하기</a></li>
+                </ul>
+                <ul>
+                    <li class="title">회사소개</li>
+                    <li><a href="#">About Nike</a></li>
+                    <li><a href="#">소식</a></li>
+                    <li><a href="#">채용</a></li>
+                    <li><a href="#">투자자</a></li>
+                    <li><a href="#">지속가능성</a></li>
+                    <li><a href="#">신고하기</a></li>
+                </ul>
+                <a href="#" class="link link-global">대한민국</a>
+            </nav>
+            <ul class="menu">
+                <li>&copy; 2025 Nike, Inc. All Rights Reserved</li>
+                <li><a href="#">이용약관</a></li>
+                <li><a href="#"><strong>개인정보처리방침</strong></a></li>
+                <li><a href="#">위치정보이용약관</a></li>
+                <li><a href="#">영상정보처리기기 운영 방침</a></li>
+            </ul>
+            <div class="txt">
+                <div>
+                    <p>
+                        <span>유)나이키코리아 대표 Kimberlee Lynn Chang Mendes, 킴벌리 린 창 멘데스</span>
+                        <span>서울 강남구 테헤란로 152 강남파이낸스센터 30층</span>
+                        <span>통신판매업신고번호 2011-서울강남-03461</span>
+                        <span>
                         등록번호 220-88-09068
                         <a href="#">사업자 정보 확인</a>
                     </span>
-                        </p>
-                        <p>
+                    </p>
+                    <p>
                     <span>
                         고객센터 전화 문의
                         <a href="tel:#">080-022-0182</a>
                         FAX 02-6744-5880
                     </span>
-                            <span>
+                        <span>
                         이메일
                         <a href="mailto:#">service@nike.co.kr</a>
                     </span>
-                            <span>호스팅서비스사업자 (유)나이키코리아</span>
-                        </p>
-                    </div>
-                    <p>
-                        현금 등으로 결제 시 안전 거래를 위해 나이키 쇼핑몰에서 가입하신 한국결제네트웍스 유한회사의 구매안전 서비스(결제대금예치)를 이용하실 수 있습니다.
-                        콘텐츠산업진흥법에 의한 콘텐츠 보호 안내
-                        <a href="#">자세히 보기</a>
+                        <span>호스팅서비스사업자 (유)나이키코리아</span>
                     </p>
                 </div>
-            </footer>
+                <p>
+                    현금 등으로 결제 시 안전 거래를 위해 나이키 쇼핑몰에서 가입하신 한국결제네트웍스 유한회사의 구매안전 서비스(결제대금예치)를 이용하실 수 있습니다.
+                    콘텐츠산업진흥법에 의한 콘텐츠 보호 안내
+                    <a href="#">자세히 보기</a>
+                </p>
+            </div>
+        </footer>
 
 
     </main>


### PR DESCRIPTION
## 작업 내용
- main-kdh.html 파일 내 중복된 `<body>` 태그를 제거했습니다.
- HTML 문법 오류를 해결하여 렌더링 이상 가능성을 방지했습니다.

## 수정 이유
- HTML은 `<body>` 태그를 한 번만 사용할 수 있으며, 중복 시 브라우저에 따라 예외적인 렌더링 오류가 발생할 수 있습니다.
- 문서 구조의 일관성과 표준 준수를 위해 불필요한 태그를 제거했습니다.

## 확인 방법
- 메인 페이지를 열었을 때 정상적으로 구조가 유지되고 오류 없이 동작하는지 확인합니다.
- 인텔리제이나 브라우저 개발자 도구에서 HTML 구조를 확인했을 때 `<body>` 태그가 한 번만 선언되어 있는지 검토합니다.